### PR TITLE
The custom `Accept` header is not needed anymore.

### DIFF
--- a/src/main/scala/tv/teads/github/api/http/GithubMediaTypes.scala
+++ b/src/main/scala/tv/teads/github/api/http/GithubMediaTypes.scala
@@ -3,6 +3,5 @@ package tv.teads.github.api.http
 object GithubMediaTypes {
   val DefaultMediaType = "application/vnd.github.v3+json"
   val TestMediaType = "application/vnd.github.moondragon+json"
-  val PermissionMediaType = "application/vnd.github.ironman-preview+json"
   val RawContentMediaType = "application/vnd.github.v3.raw"
 }

--- a/src/main/scala/tv/teads/github/api/services/TeamService.scala
+++ b/src/main/scala/tv/teads/github/api/services/TeamService.scala
@@ -44,8 +44,7 @@ class TeamService(config: GithubApiClientConfig) extends GithubService(config) w
   def fetchTeamMembers(id: Long)(implicit ec: ExecutionContext): Future[List[Member]] = {
     fetchMultiple[Member](
       s"teams/$id/members",
-      s"Fetching team $id members failed",
-      mediaType = GithubMediaTypes.PermissionMediaType
+      s"Fetching team $id members failed"
     )
   }
 
@@ -85,7 +84,7 @@ class TeamService(config: GithubApiClientConfig) extends GithubService(config) w
   def addTeamMembership(id: Long, username: String, membership: Membership)(implicit ec: ExecutionContext): Future[Boolean] = {
     val url = s"${config.apiUrl}/teams/$id/memberships/$username"
     val requestBuilder = new Request.Builder().url(url).put(Map("body" → membership).toJson)
-    baseRequest(requestBuilder, GithubMediaTypes.PermissionMediaType).map {
+    baseRequest(requestBuilder).map {
       case response if response.code() == 200 ⇒ true
       case response ⇒
         failedRequest(s"Adding user $username as member of team $id failed", response.code(), false)
@@ -111,7 +110,7 @@ class TeamService(config: GithubApiClientConfig) extends GithubService(config) w
   def addTeamRepo(id: Long, repository: String, permission: Permission)(implicit ec: ExecutionContext): Future[Boolean] = {
     val url = s"${config.apiUrl}/teams/$id/repos/${config.owner}/$repository"
     val requestBuilder = new Request.Builder().url(url).put(Map("body" → permission).toJson)
-    baseRequest(requestBuilder, GithubMediaTypes.PermissionMediaType).map {
+    baseRequest(requestBuilder).map {
       case response if response.code() == 204 ⇒ true
       case response ⇒
         failedRequest(s"Adding repository $repository to team $id failed", response.code(), false)
@@ -131,7 +130,7 @@ class TeamService(config: GithubApiClientConfig) extends GithubService(config) w
   def isRepoManagedByTeam(id: Long, repository: String)(implicit ec: ExecutionContext): Future[Boolean] = {
     val url = s"${config.apiUrl}/teams/$id/repos/${config.owner}/$repository"
     val requestBuilder = new Request.Builder().url(url).get()
-    baseRequest(requestBuilder, GithubMediaTypes.PermissionMediaType).map {
+    baseRequest(requestBuilder).map {
       case response if response.code() == 204 ⇒ true
       case response ⇒
         failedRequest(s"Checking if repository $repository is managed by team $id failed", response.code(), false)
@@ -141,7 +140,7 @@ class TeamService(config: GithubApiClientConfig) extends GithubService(config) w
   def create(team: Team)(implicit ec: ExecutionContext): Future[Option[Team]] = {
     val url = s"${config.apiUrl}/orgs/${config.owner}/teams"
     val requestBuilder = new Request.Builder().url(url).post(team.toJson)
-    baseRequest(requestBuilder, GithubMediaTypes.PermissionMediaType).map {
+    baseRequest(requestBuilder).map {
       _.as[Team].fold(
         code ⇒ failedRequest(s"Creating team $team failed", code, None),
         decodedResponse ⇒ Some(decodedResponse.decoded)
@@ -152,7 +151,7 @@ class TeamService(config: GithubApiClientConfig) extends GithubService(config) w
   def edit(id: Long, team: Team)(implicit ec: ExecutionContext): Future[Option[Team]] = {
     val url = s"${config.apiUrl}/teams/$id"
     val requestBuilder = new Request.Builder().url(url).patch(team.toJson)
-    baseRequest(requestBuilder, GithubMediaTypes.PermissionMediaType).map {
+    baseRequest(requestBuilder).map {
       _.as[Team].fold(
         code ⇒ failedRequest(s"Editing team $team failed", code, None),
         decodedResponse ⇒ Some(decodedResponse.decoded)


### PR DESCRIPTION
https://developer.github.com/changes/2016-01-05-api-enhancements-for-working-with-organization-permissions-are-now-official/